### PR TITLE
np.math.factorial does not exist

### DIFF
--- a/src/jmp/models/gemnet/layers/basis_utils.py
+++ b/src/jmp/models/gemnet/layers/basis_utils.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import numpy as np
 import sympy as sym
 import torch
+import math
 from scipy import special as sp
 from scipy.optimize import brentq
 
@@ -115,8 +116,8 @@ def sph_harm_prefactor(l_degree, m_order):
     return (
         (2 * l_degree + 1)
         / (4 * np.pi)
-        * np.math.factorial(l_degree - abs(m_order))
-        / np.math.factorial(l_degree + abs(m_order))
+        * math.factorial(l_degree - abs(m_order))
+        / math.factorial(l_degree + abs(m_order))
     ) ** 0.5
 
 


### PR DESCRIPTION
In `src/jmp/models/gemnet/layers/basis_utils.py`, np.math.factorial is called on lines 119 and 120. However, it seems like np.math.factorial does not exist. Therefore, I simply replaced it with the built-in math.factorial function.

This change was required for me to be able to use jmp-backbone in MatterTune